### PR TITLE
fix: typos in components name and warnings about name styles

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- eslint warnings
+
 ## [v0.4.0] - 12.02.2025
 
 ### Changed

--- a/src/components/ScTag/ScTag.tsx
+++ b/src/components/ScTag/ScTag.tsx
@@ -97,7 +97,7 @@ export const ContextMenu = ({ addr, systemId, targetRef, relativeRef, onClose }:
   return (
     <StyledDropdown ref={dropdownRef} targetRef={targetRef} relativeRef={relativeRef}>
       {isLoading && (
-        <StyledDropdownOption isload>
+        <StyledDropdownOption $isLoad>
           <Spinner size={24} appearance={SPINNER_COLOR} />
           {translate({ ru: 'Идет загрузка', en: 'Loading' })}
         </StyledDropdownOption>

--- a/src/components/ScTag/ScTag.tsx
+++ b/src/components/ScTag/ScTag.tsx
@@ -6,7 +6,7 @@ import { useBooleanState } from '@hooks/useBooleanState';
 import { useClickOutside } from '@hooks/useClickOutside';
 import styled, { css } from 'styled-components';
 
-import { SPINER_COLOR } from './constants';
+import { SPINNER_COLOR } from './constants';
 import { IContextItem } from './model';
 import { StyledDropdown, StyledDropdownOption } from './styled';
 import { useContextMenu } from './useContextMenu';
@@ -97,8 +97,8 @@ export const ContextMenu = ({ addr, systemId, targetRef, relativeRef, onClose }:
   return (
     <StyledDropdown ref={dropdownRef} targetRef={targetRef} relativeRef={relativeRef}>
       {isLoading && (
-        <StyledDropdownOption isLoad>
-          <Spinner size={24} appearance={SPINER_COLOR} />
+        <StyledDropdownOption isload>
+          <Spinner size={24} appearance={SPINNER_COLOR} />
           {translate({ ru: 'Идет загрузка', en: 'Loading' })}
         </StyledDropdownOption>
       )}

--- a/src/components/ScTag/constants.ts
+++ b/src/components/ScTag/constants.ts
@@ -1,1 +1,1 @@
-export const SPINER_COLOR = '#5896C0';
+export const SPINNER_COLOR = '#5896C0';

--- a/src/components/ScTag/styled.ts
+++ b/src/components/ScTag/styled.ts
@@ -15,13 +15,13 @@ export const StyledDropdown = styled(Dropdown)`
   overflow: auto;
 `;
 
-export const StyledDropdownOption = styled(DropdownOption)<{ isload?: boolean }>`
+export const StyledDropdownOption = styled(DropdownOption)<{ $isLoad?: boolean }>`
   &:hover {
     background-color: #f5f5f5;
   }
 
   ${(props) =>
-    props.isload &&
+    props.$isLoad &&
     css`
       display: flex;
       align-items: center;

--- a/src/components/ScTag/styled.ts
+++ b/src/components/ScTag/styled.ts
@@ -15,13 +15,13 @@ export const StyledDropdown = styled(Dropdown)`
   overflow: auto;
 `;
 
-export const StyledDropdownOption = styled(DropdownOption)<{ isLoad?: boolean }>`
+export const StyledDropdownOption = styled(DropdownOption)<{ isload?: boolean }>`
   &:hover {
     background-color: #f5f5f5;
   }
 
   ${(props) =>
-    props.isLoad &&
+    props.isload &&
     css`
       display: flex;
       align-items: center;

--- a/src/components/Scg/Scg.tsx
+++ b/src/components/Scg/Scg.tsx
@@ -9,7 +9,7 @@ import { snakeToCamelCase } from '@utils/snakeToCamelCase';
 import { Frame, StyledSpinner, Wrap } from './styled';
 import { EWindowEvents, ITarget, IWindowEventData } from './types';
 
-const SPINER_COLOR = '#5896C0';
+const SPINNER_COLOR = '#5896C0';
 
 const readonlyStyle = `
   <style>
@@ -42,14 +42,14 @@ export const Scg: FC<IScgProps> = ({
   onEmptyFragment,
   onFullfilledFragment,
 }) => {
-  const [isReady, setIsready] = useState(false);
+  const [isReady, setIsReady] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [targetNode, setTargetNode] = useState<ITarget | null>(null);
   const [isConfirmDeletePopupShown, showConfirmDeletePopup, hideConfirmDeletePopup] = useBooleanState(false);
   const [isConfirmClearScenePopupShown, showConfirmClearScenePopup, hideConfirmClearScenePopup] =
     useBooleanState(false);
   const [confirmDeleteElementsFunc, setConfirmDeleteElementsFunc] = useState<any>();
-  const [confirmClearSceneFunc, setconfirmClearSceneFunc] = useState<any>();
+  const [confirmClearSceneFunc, setConfirmClearSceneFunc] = useState<any>();
 
   const ref = useRef<HTMLIFrameElement>(null);
   const targetRef = useRef<HTMLElement | null>(null);
@@ -79,7 +79,7 @@ export const Scg: FC<IScgProps> = ({
     const iframe = ref.current;
     if (!iframe) return setIsLoading(false);
     (iframe.contentWindow as any).onInitializationFinished = () => {
-      setIsready(true);
+      setIsReady(true);
     };
 
     (iframe.contentWindow as any).demoImplementation = true;
@@ -108,7 +108,7 @@ export const Scg: FC<IScgProps> = ({
           break;
         case EWindowEvents.clearScene:
           showConfirmClearScenePopup();
-          setconfirmClearSceneFunc(() => (iframe.contentWindow as any)?.clearScene);
+          setConfirmClearSceneFunc(() => (iframe.contentWindow as any)?.clearScene);
           break;
         case EWindowEvents.updateScg:
           if (!action) break;
@@ -145,7 +145,7 @@ export const Scg: FC<IScgProps> = ({
 
   return (
     <Wrap show={show} className={className}>
-      {isLoading && <StyledSpinner appearance={SPINER_COLOR} />}
+      {isLoading && <StyledSpinner appearance={SPINNER_COLOR} />}
       <Frame src={url} ref={ref} title="SCg codes" />
       {targetNode && <ContextMenu onClose={onClose} addr={targetNode.addr} relativeRef={ref} targetRef={targetRef} />}
     </Wrap>

--- a/src/components/Scg/styled.ts
+++ b/src/components/Scg/styled.ts
@@ -29,8 +29,8 @@ export const Frame = styled.iframe`
   border: 0;
 `;
 
-export const Popup = styled.div<{ isClear?: boolean }>`
-  width: ${(props) => (props.isClear ? '383px' : '344px')};
+export const Popup = styled.div<{ isclear?: boolean }>`
+  width: ${(props) => (props.isclear ? '383px' : '344px')};
 
   font-family: 'Roboto';
   font-style: normal;

--- a/src/components/Scg/styled.ts
+++ b/src/components/Scg/styled.ts
@@ -29,8 +29,8 @@ export const Frame = styled.iframe`
   border: 0;
 `;
 
-export const Popup = styled.div<{ isclear?: boolean }>`
-  width: ${(props) => (props.isclear ? '383px' : '344px')};
+export const Popup = styled.div<{ $isClear?: boolean }>`
+  width: ${(props) => (props.$isClear ? '383px' : '344px')};
 
   font-family: 'Roboto';
   font-style: normal;

--- a/src/components/SwitchScgScn/SwitchScgScn.tsx
+++ b/src/components/SwitchScgScn/SwitchScgScn.tsx
@@ -21,13 +21,13 @@ export const SwitchScgScn = ({ tab, className, onTabClick }: ISwitchScgScnProps)
     <SwitchWrap className={className}>
       <Tabs>
         <Tooltip title={'SCn-код'}>
-          <Tab isactive={tab === 'scn'} onClick={onClick('scn')}>
+          <Tab $isActive={tab === 'scn'} onClick={onClick('scn')}>
             <ScnSwitch />
           </Tab>
         </Tooltip>
         <Divider />
         <Tooltip title={'SCg-код'} placement="bottom-end">
-          <Tab isactive={tab === 'scg'} onClick={onClick('scg')}>
+          <Tab $isActive={tab === 'scg'} onClick={onClick('scg')}>
             <ScgSwitch />
           </Tab>
         </Tooltip>

--- a/src/components/SwitchScgScn/SwitchScgScn.tsx
+++ b/src/components/SwitchScgScn/SwitchScgScn.tsx
@@ -21,13 +21,13 @@ export const SwitchScgScn = ({ tab, className, onTabClick }: ISwitchScgScnProps)
     <SwitchWrap className={className}>
       <Tabs>
         <Tooltip title={'SCn-код'}>
-          <Tab isActive={tab === 'scn'} onClick={onClick('scn')}>
+          <Tab isactive={tab === 'scn'} onClick={onClick('scn')}>
             <ScnSwitch />
           </Tab>
         </Tooltip>
         <Divider />
         <Tooltip title={'SCg-код'} placement="bottom-end">
-          <Tab isActive={tab === 'scg'} onClick={onClick('scg')}>
+          <Tab isactive={tab === 'scg'} onClick={onClick('scg')}>
             <ScgSwitch />
           </Tab>
         </Tooltip>

--- a/src/components/SwitchScgScn/styled.ts
+++ b/src/components/SwitchScgScn/styled.ts
@@ -13,7 +13,7 @@ export const Tabs = styled.div`
   width: 100%;
 `;
 
-export const Tab = styled.div<{ isActive: boolean }>`
+export const Tab = styled.div<{ isactive: boolean }>`
   font-size: 26px;
   font-weight: 400;
   color: #c0c0c0;
@@ -36,7 +36,7 @@ export const Tab = styled.div<{ isActive: boolean }>`
   }
 
   ${(props) =>
-    props.isActive &&
+    props.isactive &&
     css`
       background: #f8f8f8;
 

--- a/src/components/SwitchScgScn/styled.ts
+++ b/src/components/SwitchScgScn/styled.ts
@@ -13,7 +13,7 @@ export const Tabs = styled.div`
   width: 100%;
 `;
 
-export const Tab = styled.div<{ isactive: boolean }>`
+export const Tab = styled.div<{ $isActive: boolean }>`
   font-size: 26px;
   font-weight: 400;
   color: #c0c0c0;
@@ -36,7 +36,7 @@ export const Tab = styled.div<{ isactive: boolean }>`
   }
 
   ${(props) =>
-    props.isactive &&
+    props.$isActive &&
     css`
       background: #f8f8f8;
 

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -17,8 +17,8 @@ const fadeOut = keyframes`
   }
 `;
 
-const ToastWrapper = styled.div<{ $isDisapearing?: boolean }>`
-  animation: ${({ $isDisapearing }) => ($isDisapearing ? fadeOut : fadeIn)} 0.3s ease both;
+const ToastWrapper = styled.div<{ $isDisappearing?: boolean }>`
+  animation: ${({ $isDisappearing }) => ($isDisappearing ? fadeOut : fadeIn)} 0.3s ease both;
 `;
 
 interface IProps {
@@ -45,14 +45,14 @@ export const Toast = ({ id }: IProps) => {
     ? cloneElement(toast.component, { onClose: toast.params.closeable ? onClose : undefined })
     : null;
 
-  const isDisapearing = deletingToasts.includes(id);
+  const isDisappearing = deletingToasts.includes(id);
 
   const onAnimationEnd = () => {
-    if (isDisapearing) removeToast(id);
+    if (isDisappearing) removeToast(id);
   };
 
   return (
-    <ToastWrapper $isDisapearing={isDisapearing} onAnimationEnd={onAnimationEnd}>
+    <ToastWrapper $isDisappearing={isDisappearing} onAnimationEnd={onAnimationEnd}>
       {newComponent}
     </ToastWrapper>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix typos and naming conventions in components, focusing on `ScTag`, `Scg`, `SwitchScgScn`, and `Toast`.
> 
>   - **Typos and Naming Fixes**:
>     - Correct `SPINER_COLOR` to `SPINNER_COLOR` in `ScTag.tsx`, `Scg.tsx`, and `constants.ts`.
>     - Fix `isready` to `isReady` and `setconfirmClearSceneFunc` to `setConfirmClearSceneFunc` in `Scg.tsx`.
>     - Correct `isDisapearing` to `isDisappearing` in `Toast.tsx`.
>   - **Styled Component Prop Naming**:
>     - Rename `isLoad` to `$isLoad` in `styled.ts` for `StyledDropdownOption`.
>     - Rename `isActive` to `$isActive` in `styled.ts` for `Tab`.
>     - Rename `isClear` to `$isClear` in `styled.ts` for `Popup`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fostis-ui-lib&utm_source=github&utm_medium=referral)<sup> for dd278f2f85b82807ebdbcd2aa399a3b6149bca96. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->