### PR TITLE
feat: add cache for main idtf link search

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Cache for main identifier link search;
+
 ## [v0.4.2] - 14.03.2025
 
 ## Fixed

--- a/src/components/ScUtils/scUtilsBuilder.ts
+++ b/src/components/ScUtils/scUtilsBuilder.ts
@@ -51,7 +51,6 @@ export const scUtilsBuilder = ({ client }: IProps) => {
         const keynodes = await searchKeynodes("lang_ru", "lang_en");
         await Promise.all(
           Object.entries(keynodes).map(async ([key, value]) => {
-            console.log(key, value);
             for (const lang of languages) {
               const mainIdLink = await getMainIdLinkAddrWithoutCache(value, lang);
               if (!mainIdLink) continue;

--- a/src/components/ScUtils/scUtilsBuilder.ts
+++ b/src/components/ScUtils/scUtilsBuilder.ts
@@ -74,7 +74,7 @@ export const scUtilsBuilder = ({ client }: IProps) => {
       await initializationPromise;
     }
 
-    const { ...language } = await searchKeynodes(langToKeynode[lang]);
+    const language = await searchKeynodes(langToKeynode[lang]);
     const foundLang = language[snakeToCamelCase(langToKeynode[lang])];
 
     const cacheKey = `${addr.value}_${foundLang.value}`;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds caching for main identifier link search in `scUtilsBuilder.ts` to improve performance by reducing redundant searches.
> 
>   - **Behavior**:
>     - Adds caching for main identifier link search in `scUtilsBuilder.ts`.
>     - Initializes cache asynchronously using `initializeMainIdCache()`.
>     - Uses `mainIdCache` to store and retrieve cached results in `getMainIdLinkAddr()`.
>   - **Functions**:
>     - Adds `initializeMainIdCache()` to set up cache.
>     - Modifies `getMainIdLinkAddr()` to use cache.
>     - Introduces `mainIdCache` object to store cached data.
>   - **Misc**:
>     - Updates `changelog.md` to document the addition of the cache feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fostis-ui-lib&utm_source=github&utm_medium=referral)<sup> for 4586ac6c222e2f493fde6fbb8b6d6daae57d66ab. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->